### PR TITLE
Added the dark_cherry_logs tag files to correctly tag the various log types

### DIFF
--- a/common/src/main/resources/data/vinery/tags/blocks/dark_cherry_logs.json
+++ b/common/src/main/resources/data/vinery/tags/blocks/dark_cherry_logs.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "vinery:dark_cherry_log",
+    "vinery:stripped_dark_cherry_log",
+    "vinery:dark_cherry_wood",
+    "vinery:stripped_dark_cherry_wood"
+  ]
+}

--- a/common/src/main/resources/data/vinery/tags/items/dark_cherry_logs.json
+++ b/common/src/main/resources/data/vinery/tags/items/dark_cherry_logs.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "vinery:dark_cherry_log",
+    "vinery:stripped_dark_cherry_log",
+    "vinery:dark_cherry_wood",
+    "vinery:stripped_dark_cherry_wood"
+  ]
+}


### PR DESCRIPTION
This should address the issue I noted here for the dark cherry logs:
https://github.com/satisfyu/Let-s-Do-Hub/issues/445