### PR TITLE
Taiga grape seed trade fix

### DIFF
--- a/fabric/src/main/java/net/satisfy/vinery/fabric/config/VineryFabricConfig.java
+++ b/fabric/src/main/java/net/satisfy/vinery/fabric/config/VineryFabricConfig.java
@@ -142,8 +142,8 @@ public class VineryFabricConfig implements ConfigData {
                     trades.add(new TradeEntry("vinery:window", TradeType.SELL, 12, 1, 2, 10));
                     trades.add(new TradeEntry("vinery:dark_cherry_beam", TradeType.SELL, 6, 4, 2, 10));
                     trades.add(new TradeEntry("vinery:grapevine_pot", TradeType.SELL, 6, 1, 2, 10));
-                    trades.add(new TradeEntry("vinery:taiga_red_grape_seeds", TradeType.SELL, 2, 1, 2, 5));
-                    trades.add(new TradeEntry("vinery:taiga_white_grape_seeds", TradeType.SELL, 2, 1, 2, 5));
+                    trades.add(new TradeEntry("vinery:taiga_grape_seeds_red", TradeType.SELL, 2, 1, 2, 5));
+                    trades.add(new TradeEntry("vinery:taiga_grape_seeds_white", TradeType.SELL, 2, 1, 2, 5));
                 } else if (level == 5) {
                     trades.add(new TradeEntry("vinery:wine_box", TradeType.SELL, 10, 1, 2, 10));
                     trades.add(new TradeEntry("vinery:lilitu_wine", TradeType.SELL, 4, 1, 2, 10));

--- a/neoforge/src/main/java/net/satisfy/vinery/neoforge/core/config/VineryForgeConfig.java
+++ b/neoforge/src/main/java/net/satisfy/vinery/neoforge/core/config/VineryForgeConfig.java
@@ -193,8 +193,8 @@ public class VineryForgeConfig {
                         "vinery:window|12|1|2|true",
                         "vinery:dark_cherry_beam|6|4|2|true",
                         "vinery:grapevine_pot|6|1|2|true",
-                        "vinery:taiga_red_grape_seeds|2|1|2|true",
-                        "vinery:taiga_white_grape_seeds|2|1|2|true"
+                        "vinery:taiga_grape_seeds_red|2|1|2|true",
+                        "vinery:taiga_grape_seeds_white|2|1|2|true"
                 ), obj -> obj instanceof String);
 
         LEVEL5_TRADES = commonBuilder


### PR DESCRIPTION
Fixes the incorrect item id used in villager trades for taiga grape seeds of both types.
This caused a crash in the neoforge version. It failed silently on the fabric version but would not show the intended trades.