### PR TITLE
fix: correct taiga grape seed item IDs in winemaker trades

### DIFF
--- a/fabric/src/main/java/net/satisfy/vinery/fabric/config/VineryFabricConfig.java
+++ b/fabric/src/main/java/net/satisfy/vinery/fabric/config/VineryFabricConfig.java
@@ -142,8 +142,8 @@ public class VineryFabricConfig implements ConfigData {
                     trades.add(new TradeEntry("vinery:window", TradeType.SELL, 12, 1, 2, 10));
                     trades.add(new TradeEntry("vinery:dark_cherry_beam", TradeType.SELL, 6, 4, 2, 10));
                     trades.add(new TradeEntry("vinery:grapevine_pot", TradeType.SELL, 6, 1, 2, 10));
-                    trades.add(new TradeEntry("vinery:taiga_red_grape_seeds", TradeType.SELL, 2, 1, 2, 5));
-                    trades.add(new TradeEntry("vinery:taiga_white_grape_seeds", TradeType.SELL, 2, 1, 2, 5));
+                    trades.add(new TradeEntry("vinery:taiga_grape_seeds_red", TradeType.SELL, 2, 1, 2, 5));
+                    trades.add(new TradeEntry("vinery:taiga_grape_seeds_white", TradeType.SELL, 2, 1, 2, 5));
                 } else if (level == 5) {
                     trades.add(new TradeEntry("vinery:wine_box", TradeType.SELL, 10, 1, 2, 10));
                     trades.add(new TradeEntry("vinery:lilitu_wine", TradeType.SELL, 4, 1, 2, 10));

--- a/neoforge/src/main/java/net/satisfy/vinery/neoforge/core/config/VineryForgeConfig.java
+++ b/neoforge/src/main/java/net/satisfy/vinery/neoforge/core/config/VineryForgeConfig.java
@@ -193,8 +193,8 @@ public class VineryForgeConfig {
                         "vinery:window|12|1|2|true",
                         "vinery:dark_cherry_beam|6|4|2|true",
                         "vinery:grapevine_pot|6|1|2|true",
-                        "vinery:taiga_red_grape_seeds|2|1|2|true",
-                        "vinery:taiga_white_grape_seeds|2|1|2|true"
+                        "vinery:taiga_grape_seeds_red|2|1|2|true",
+                        "vinery:taiga_grape_seeds_white|2|1|2|true"
                 ), obj -> obj instanceof String);
 
         LEVEL5_TRADES = commonBuilder
@@ -259,8 +259,8 @@ public class VineryForgeConfig {
                 "vinery:window|12|1|2|true",
                 "vinery:dark_cherry_beam|6|4|2|true",
                 "vinery:grapevine_pot|6|1|2|true",
-                "vinery:taiga_red_grape_seeds|2|1|2|true",
-                "vinery:taiga_white_grape_seeds|2|1|2|true"
+                "vinery:taiga_grape_seeds_red|2|1|2|true",
+                "vinery:taiga_grape_seeds_white|2|1|2|true"
         );
 
         level5TradesCache = List.of(

--- a/neoforge/src/main/java/net/satisfy/vinery/neoforge/core/event/VineryForgeEventhandler.java
+++ b/neoforge/src/main/java/net/satisfy/vinery/neoforge/core/event/VineryForgeEventhandler.java
@@ -60,7 +60,7 @@ public class VineryForgeEventhandler {
             boolean isSelling = Boolean.parseBoolean(parts[4]);
 
             Item item = BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemName));
-            if (item != null) {
+            if (item != null && item != Items.AIR) {
                 VillagerTrades.ItemListing listing;
                 if (isSelling) {
                     listing = new VillagerUtil.SellItemFactory(item, price, quantity, maxUses);


### PR DESCRIPTION
Fixes winemaker villager trades using incorrect item IDs for taiga grape seeds (`taiga_red_grape_seeds` → `taiga_grape_seeds_red`, `taiga_white_grape_seeds` → `taiga_grape_seeds_white`), which causes `EncoderException: Empty ItemStack not allowed` and disconnects the player when opening the level 4 trading UI.

Also adds `Items.AIR` guard in NeoForge `loadTradesFromConfig` to match Fabric's existing check.

Fixes Let-s-Do-Collection/Let-s-Do-Collection#946
Relates to Let-s-Do-Collection/Let-s-Do-Collection#882