### PR TITLE
fix: skip light check in GrapeBush.canSurvive() during worldgen

### DIFF
--- a/common/src/main/java/net/satisfy/vinery/core/block/GrapeBush.java
+++ b/common/src/main/java/net/satisfy/vinery/core/block/GrapeBush.java
@@ -24,6 +24,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.level.chunk.status.ChunkStatus;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.BlockHitResult;
@@ -114,7 +115,13 @@ public class GrapeBush extends BushBlock implements BonemealableBlock {
 
     @Override
     public boolean canSurvive(BlockState blockState, LevelReader world, BlockPos blockPos) {
-        return canGrowPlace(world, blockPos, blockState) && this.mayPlaceOn(world.getBlockState(blockPos.below()), world, blockPos);
+        boolean soilValid = this.mayPlaceOn(world.getBlockState(blockPos.below()), world, blockPos);
+        if (!soilValid) return false;
+
+        if (world.getChunk(blockPos).getPersistedStatus().getIndex() < ChunkStatus.FULL.getIndex()) {
+            return true;
+        }
+        return canGrowPlace(world, blockPos, blockState);
     }
 
     @Override


### PR DESCRIPTION
During worldgen, ScalableLux/Starlight overrides `getRawBrightness()` to return 0, causing `canGrowPlace()` to always fail and grape bushes silently not generating. Fix by checking `ChunkStatus` to skip the light check during worldgen while preserving it during normal gameplay.

Closes Let-s-Do-Collection/Let-s-Do-Collection#1028