### PR TITLE
Add config option to completely disable any wine

### DIFF
--- a/common/src/main/java/satisfyu/vinery/client/gui/config/ClothConfigScreen.java
+++ b/common/src/main/java/satisfyu/vinery/client/gui/config/ClothConfigScreen.java
@@ -8,6 +8,7 @@ import me.shedaniel.clothconfig2.api.ConfigCategory;
 import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
 import me.shedaniel.clothconfig2.gui.entries.BooleanListEntry;
 import me.shedaniel.clothconfig2.gui.entries.IntegerListEntry;
+import me.shedaniel.clothconfig2.gui.entries.StringListListEntry;
 import me.shedaniel.clothconfig2.gui.entries.TextListEntry;
 import me.shedaniel.clothconfig2.impl.builders.SubCategoryBuilder;
 import net.minecraft.ChatFormatting;
@@ -19,6 +20,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import satisfyu.vinery.Vinery;
 import satisfyu.vinery.config.VineryConfig;
+
+import java.util.List;
 
 public class ClothConfigScreen {
 
@@ -46,6 +49,7 @@ public class ClothConfigScreen {
         private final ConfigCategory category;
         private final BooleanListEntry enableWineMakerSetBonus, enableNetherLattices;
         private final IntegerListEntry wineTraderChance, yearLengthInDays, yearsPerEffectLevel, fermentationBarrelTime, damagePerUse, probabilityForDamage, probabilityToKeepBoneMeal, grapeGrowthSpeed;
+        private final StringListListEntry disabledWines;
 
 
 
@@ -60,6 +64,12 @@ public class ClothConfigScreen {
             grapeGrowthSpeed = createIntField("grapeGrowthSpeed", config.grapeGrowthSpeed(), VineryConfig.DEFAULT.grapeGrowthSpeed(), null, 1, 100);
             enableNetherLattices = createBooleanField("enableNetherLattices", config.enableNetherLattices(), VineryConfig.DEFAULT.enableNetherLattices(), null);
 
+            disabledWines = builder.startStrList(Component.translatable("vinery.config.entry.disabledWines"), config.disabledWines())
+                    .setDefaultValue(VineryConfig.DEFAULT.disabledWines())
+                    .setTooltip(Component.translatable("vinery.config.entry.disabledWines.tooltip"))
+                    .build();
+            category.addEntry(disabledWines);
+
             SubCategoryBuilder wineMaker = new SubCategoryBuilder(Component.empty(), Component.translatable("vinery.config.subCategory.wineMaker"));
 
             enableWineMakerSetBonus = createBooleanField("enableWineMakerSetBonus", config.enableWineMakerSetBonus(), VineryConfig.DEFAULT.enableWineMakerSetBonus(), wineMaker);
@@ -73,7 +83,7 @@ public class ClothConfigScreen {
 
 
         public VineryConfig createConfig() {
-            return new VineryConfig(wineTraderChance.getValue(), yearLengthInDays.getValue(), yearsPerEffectLevel.getValue(), enableWineMakerSetBonus.getValue(), damagePerUse.getValue(), probabilityForDamage.getValue(), probabilityToKeepBoneMeal.getValue(), fermentationBarrelTime.getValue(), grapeGrowthSpeed.getValue(), enableNetherLattices.getValue());
+            return new VineryConfig(wineTraderChance.getValue(), yearLengthInDays.getValue(), yearsPerEffectLevel.getValue(), enableWineMakerSetBonus.getValue(), damagePerUse.getValue(), probabilityForDamage.getValue(), probabilityToKeepBoneMeal.getValue(), fermentationBarrelTime.getValue(), grapeGrowthSpeed.getValue(), enableNetherLattices.getValue(), disabledWines.getValue());
         }
 
 

--- a/common/src/main/java/satisfyu/vinery/config/VineryConfig.java
+++ b/common/src/main/java/satisfyu/vinery/config/VineryConfig.java
@@ -4,17 +4,20 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import de.cristelknight.doapi.config.jankson.config.CommentedConfig;
 import net.minecraft.Util;
+import net.minecraft.resources.ResourceLocation;
 
 import java.util.HashMap;
+import java.util.List;
 
 
 public record VineryConfig(int wineTraderChance, int yearLengthInDays, int yearsPerEffectLevel,
-                           boolean enableWineMakerSetBonus, int damagePerUse, int probabilityForDamage, int probabilityToKeepBoneMeal, int fermentationBarrelTime, int grapeGrowthSpeed, boolean enableNetherLattices)
+                           boolean enableWineMakerSetBonus, int damagePerUse, int probabilityForDamage, int probabilityToKeepBoneMeal, int fermentationBarrelTime, int grapeGrowthSpeed, boolean enableNetherLattices,
+                           List<String> disabledWines)
         implements CommentedConfig<VineryConfig> {
 
     private static VineryConfig INSTANCE = null;
 
-    public static final VineryConfig DEFAULT = new VineryConfig(50, 16, 4, true, 1, 30, 100, 50, 100, false);
+    public static final VineryConfig DEFAULT = new VineryConfig(50, 16, 4, true, 1, 30, 100, 50, 100, false, List.of());
 
     public static final Codec<VineryConfig> CODEC = RecordCodecBuilder.create(builder ->
             builder.group(
@@ -27,7 +30,8 @@ public record VineryConfig(int wineTraderChance, int yearLengthInDays, int years
                     Codec.intRange(1, 100).fieldOf("probability_to_keep_bone_meal").orElse(DEFAULT.probabilityToKeepBoneMeal).forGetter(c -> c.probabilityToKeepBoneMeal),
                     Codec.intRange(1, 10000).fieldOf("fermentation_barrel_time").orElse(DEFAULT.fermentationBarrelTime).forGetter(c -> c.fermentationBarrelTime),
                     Codec.intRange(0, 100).fieldOf("grape_growth_speed").orElse(DEFAULT.grapeGrowthSpeed).forGetter(c -> c.grapeGrowthSpeed),
-                    Codec.BOOL.fieldOf("enable_nether_lattices").orElse(DEFAULT.enableNetherLattices).forGetter(c -> c.enableNetherLattices)
+                    Codec.BOOL.fieldOf("enable_nether_lattices").orElse(DEFAULT.enableNetherLattices).forGetter(c -> c.enableNetherLattices),
+                    Codec.STRING.listOf().fieldOf("disabled_wines").orElse(DEFAULT.disabledWines).forGetter(c -> c.disabledWines)
             ).apply(builder, VineryConfig::new)
     );
 
@@ -55,6 +59,9 @@ public record VineryConfig(int wineTraderChance, int yearLengthInDays, int years
                     Ticks it takes to ferment a bottle""");
             map.put("enable_nether_lattices", """
                     (It is recommended to download NetherVinery instead)""");
+            map.put("disabled_wines", """
+                    List of wine item IDs to completely disable (e.g. vinery:eiswein).
+                    Disabled wines can't be crafted, are hidden from the creative menu / JEI / REI / villager trades, and existing bottles can't be drunk.""");
         });
     }
 
@@ -97,5 +104,16 @@ public record VineryConfig(int wineTraderChance, int yearLengthInDays, int years
     @Override
     public void setInstance(VineryConfig instance) {
         INSTANCE = instance;
+    }
+
+    /** True if the given item id is listed in {@code disabled_wines}. */
+    public boolean isWineDisabled(ResourceLocation id) {
+        return id != null && this.disabledWines.contains(id.toString());
+    }
+
+    /** Convenience accessor against the currently-loaded config; safe to call before the config is loaded. */
+    public static boolean isDisabled(ResourceLocation id) {
+        VineryConfig config = DEFAULT.getConfig();
+        return config != null && config.isWineDisabled(id);
     }
 }

--- a/common/src/main/java/satisfyu/vinery/dynamicassets/VineryServerDataProvider.java
+++ b/common/src/main/java/satisfyu/vinery/dynamicassets/VineryServerDataProvider.java
@@ -6,13 +6,18 @@ import net.mehvahdjukaar.moonlight.api.resources.pack.DynamicDataPack;
 import net.mehvahdjukaar.moonlight.api.resources.pack.DynamicTexturePack;
 import net.mehvahdjukaar.moonlight.api.set.BlockSetAPI;
 import net.mehvahdjukaar.moonlight.api.set.wood.WoodType;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.util.GsonHelper;
 import org.apache.logging.log4j.Logger;
 import satisfyu.vinery.Vinery;
 import satisfyu.vinery.VineryIdentifier;
 import satisfyu.vinery.config.VineryConfig;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class VineryServerDataProvider {
@@ -55,6 +60,43 @@ public class VineryServerDataProvider {
                 latticeCount.getAndIncrement();
             });
             this.getLogger().debug("Generated {} lattice recipes", latticeCount);
+
+            // Keep the "wine_collector" advancement completable when wines are disabled: its single
+            // criterion requires holding every wine at once, so drop any disabled wine's requirement.
+            List<String> disabledWines = VineryConfig.DEFAULT.getConfig().disabledWines();
+            if (disabledWines != null && !disabledWines.isEmpty()) {
+                try {
+                    StaticResource wineCollector = StaticResource.getOrFail(resourceManager, new VineryIdentifier("advancements/main/wine_collector.json"));
+                    this.addSimilarJsonResource(resourceManager, wineCollector,
+                            content -> filterWineCollector(content, disabledWines),
+                            path -> path);
+                    this.getLogger().info("Patched wine_collector advancement to skip {} disabled wine(s)", disabledWines.size());
+                } catch (Exception e) {
+                    this.getLogger().error("Failed to patch wine_collector advancement for disabled wines", e);
+                }
+            }
+        }
+
+        /** Removes any {@code inventory_changed} item predicate that references a disabled wine. */
+        private static String filterWineCollector(String json, List<String> disabledWines) {
+            JsonObject obj = GsonHelper.parse(json);
+            JsonObject conditions = obj.getAsJsonObject("criteria").getAsJsonObject("get_wines").getAsJsonObject("conditions");
+            JsonArray items = conditions.getAsJsonArray("items");
+            JsonArray kept = new JsonArray();
+            for (JsonElement entry : items) {
+                boolean disabled = false;
+                for (JsonElement id : entry.getAsJsonObject().getAsJsonArray("items")) {
+                    if (disabledWines.contains(id.getAsString())) {
+                        disabled = true;
+                        break;
+                    }
+                }
+                if (!disabled) {
+                    kept.add(entry);
+                }
+            }
+            conditions.add("items", kept);
+            return obj.toString();
         }
     }
 }

--- a/common/src/main/java/satisfyu/vinery/entity/wanderingwinemaker/WanderingWinemakerEntity.java
+++ b/common/src/main/java/satisfyu/vinery/entity/wanderingwinemaker/WanderingWinemakerEntity.java
@@ -5,6 +5,8 @@ import net.minecraft.world.entity.npc.VillagerTrades;
 import net.minecraft.world.entity.npc.WanderingTrader;
 import net.minecraft.world.item.trading.MerchantOffers;
 import net.minecraft.world.level.Level;
+import net.minecraft.core.registries.BuiltInRegistries;
+import satisfyu.vinery.config.VineryConfig;
 import satisfyu.vinery.registry.ObjectRegistry;
 
 import java.util.HashMap;
@@ -49,6 +51,7 @@ public class WanderingWinemakerEntity extends WanderingTrader {
 			this.offers = new MerchantOffers();
 		}
 		this.addOffersFromItemListings(this.offers, TRADES.get(1), 8);
+		this.offers.removeIf(offer -> VineryConfig.isDisabled(BuiltInRegistries.ITEM.getKey(offer.getResult().getItem())));
 	}
 
 }

--- a/common/src/main/java/satisfyu/vinery/item/DrinkBlockItem.java
+++ b/common/src/main/java/satisfyu/vinery/item/DrinkBlockItem.java
@@ -5,6 +5,7 @@ import com.mojang.datafixers.util.Pair;
 import de.cristelknight.doapi.common.block.entity.StorageBlockEntity;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.InteractionHand;
@@ -22,6 +23,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
+import satisfyu.vinery.config.VineryConfig;
 import satisfyu.vinery.registry.ObjectRegistry;
 import satisfyu.vinery.util.GeneralUtil;
 import satisfyu.vinery.util.WineYears;
@@ -144,6 +146,10 @@ public class DrinkBlockItem extends BlockItem {
 
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand interactionHand) {
+        if (VineryConfig.isDisabled(BuiltInRegistries.ITEM.getKey(this))) {
+            // Disabled wines are inert: any existing bottle can't be drunk.
+            return InteractionResultHolder.fail(player.getItemInHand(interactionHand));
+        }
         return ItemUtils.startUsingInstantly(level, player, interactionHand);
     }
 }

--- a/common/src/main/java/satisfyu/vinery/mixin/RecipeManagerMixin.java
+++ b/common/src/main/java/satisfyu/vinery/mixin/RecipeManagerMixin.java
@@ -1,0 +1,105 @@
+package satisfyu.vinery.mixin;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonElement;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.item.crafting.RecipeType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import satisfyu.vinery.config.VineryConfig;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Drops any recipe whose result item is a disabled wine (see {@code disabled_wines} in the Vinery config),
+ * regardless of recipe type. This single hook covers the fermentation barrel, the apple press, and Create
+ * mixing/pressing recipes (Create's {@code ProcessingRecipe#getResultItem} returns its first rollable output,
+ * and every Vinery wine recipe is single-output). JEI, REI and the vanilla recipe book inherit the filtered
+ * set for free because they all read from the (client-synced) RecipeManager.
+ * <p>
+ * The only theoretical gap is a disabled wine appearing as a non-first output of a multi-output recipe (no
+ * Vinery recipe does this); recipes whose {@link Recipe#getResultItem} throws are skipped defensively.
+ * <p>
+ * {@code apply} only runs on the logical server (datapack load); the client receives the already-filtered set
+ * via the recipe sync packet, so this does not need to run client-side.
+ */
+@Mixin(RecipeManager.class)
+public abstract class RecipeManagerMixin {
+
+    @Shadow private Map<RecipeType<?>, Map<ResourceLocation, Recipe<?>>> recipes;
+
+    @Shadow private Map<ResourceLocation, Recipe<?>> byName;
+
+    private static final Logger VINERY$LOGGER = LoggerFactory.getLogger("Vinery/DisabledWines");
+
+    @Inject(
+            method = "apply(Ljava/util/Map;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)V",
+            at = @At("TAIL")
+    )
+    private void vinery$filterDisabledWines(Map<ResourceLocation, JsonElement> object, ResourceManager resourceManager, ProfilerFiller profiler, CallbackInfo ci) {
+        VineryConfig config = VineryConfig.DEFAULT.getConfig();
+        if (config == null) {
+            return;
+        }
+        List<String> disabled = config.disabledWines();
+        if (disabled == null || disabled.isEmpty()) {
+            return;
+        }
+
+        int[] removed = {0};
+
+        Map<ResourceLocation, Recipe<?>> newByName = new HashMap<>();
+        this.byName.forEach((id, recipe) -> {
+            if (vinery$isDisabledResult(recipe)) {
+                removed[0]++;
+            } else {
+                newByName.put(id, recipe);
+            }
+        });
+
+        Map<RecipeType<?>, Map<ResourceLocation, Recipe<?>>> newByType = new HashMap<>();
+        this.recipes.forEach((type, byId) -> {
+            Map<ResourceLocation, Recipe<?>> kept = new HashMap<>();
+            byId.forEach((id, recipe) -> {
+                if (!vinery$isDisabledResult(recipe)) {
+                    kept.put(id, recipe);
+                }
+            });
+            newByType.put(type, ImmutableMap.copyOf(kept));
+        });
+
+        this.byName = ImmutableMap.copyOf(newByName);
+        this.recipes = ImmutableMap.copyOf(newByType);
+
+        if (removed[0] > 0) {
+            VINERY$LOGGER.info("Removed {} recipe(s) producing disabled wines: {}", removed[0], disabled);
+        }
+    }
+
+    private boolean vinery$isDisabledResult(Recipe<?> recipe) {
+        try {
+            ItemStack result = recipe.getResultItem(RegistryAccess.EMPTY);
+            if (result == null || result.isEmpty()) {
+                return false;
+            }
+            return VineryConfig.isDisabled(BuiltInRegistries.ITEM.getKey(result.getItem()));
+        } catch (Throwable t) {
+            // A misbehaving third-party recipe must never break datapack loading.
+            return false;
+        }
+    }
+}

--- a/common/src/main/java/satisfyu/vinery/registry/TabRegistry.java
+++ b/common/src/main/java/satisfyu/vinery/registry/TabRegistry.java
@@ -3,12 +3,15 @@ package satisfyu.vinery.registry;
 import dev.architectury.registry.registries.DeferredRegister;
 import dev.architectury.registry.registries.RegistrySupplier;
 import net.mehvahdjukaar.moonlight.api.set.wood.WoodType;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
 import satisfyu.vinery.Vinery;
+import satisfyu.vinery.config.VineryConfig;
 
 import static com.mojang.serialization.codecs.RecordCodecBuilder.build;
 
@@ -91,33 +94,33 @@ public class TabRegistry {
                 out.accept(ObjectRegistry.JUNGLE_WHITE_GRAPEJUICE_BOTTLE.get());
                 out.accept(ObjectRegistry.SAVANNA_RED_GRAPEJUICE_BOTTLE.get());
                 out.accept(ObjectRegistry.SAVANNA_WHITE_GRAPEJUICE_BOTTLE.get());
-                out.accept(ObjectRegistry.CHORUS_WINE.get());
-                out.accept(ObjectRegistry.CHERRY_WINE.get());
-                out.accept(ObjectRegistry.MAGNETIC_WINE.get());
-                out.accept(ObjectRegistry.NOIR_WINE.get());
-                out.accept(ObjectRegistry.LILITU_WINE.get());
-                out.accept(ObjectRegistry.MELLOHI_WINE.get());
-                out.accept(ObjectRegistry.STAL_WINE.get());
-                out.accept(ObjectRegistry.STRAD_WINE.get());
-                out.accept(ObjectRegistry.SOLARIS_WINE.get());
-                out.accept(ObjectRegistry.BOLVAR_WINE.get());
-                out.accept(ObjectRegistry.AEGIS_WINE.get());
-                out.accept(ObjectRegistry.CLARK_WINE.get());
-                out.accept(ObjectRegistry.CHENET_WINE.get());
-                out.accept(ObjectRegistry.KELP_CIDER.get());
-                out.accept(ObjectRegistry.APPLE_WINE.get());
-                out.accept(ObjectRegistry.APPLE_CIDER.get());
-                out.accept(ObjectRegistry.JELLIE_WINE.get());
-                out.accept(ObjectRegistry.RED_WINE.get());
-                out.accept(ObjectRegistry.PRAETORIAN_WINE.get());
-                out.accept(ObjectRegistry.JO_SPECIAL_MIXTURE.get());
-                out.accept(ObjectRegistry.CRISTEL_WINE.get());
-                out.accept(ObjectRegistry.CREEPERS_CRUSH.get());
-                out.accept(ObjectRegistry.VILLAGERS_FRIGHT.get());
-                out.accept(ObjectRegistry.GLOWING_WINE.get());
-                out.accept(ObjectRegistry.MEAD.get());
-                out.accept(ObjectRegistry.BOTTLE_MOJANG_NOIR.get());
-                out.accept(ObjectRegistry.EISWEIN.get());
+                acceptWine(out, ObjectRegistry.CHORUS_WINE.get());
+                acceptWine(out, ObjectRegistry.CHERRY_WINE.get());
+                acceptWine(out, ObjectRegistry.MAGNETIC_WINE.get());
+                acceptWine(out, ObjectRegistry.NOIR_WINE.get());
+                acceptWine(out, ObjectRegistry.LILITU_WINE.get());
+                acceptWine(out, ObjectRegistry.MELLOHI_WINE.get());
+                acceptWine(out, ObjectRegistry.STAL_WINE.get());
+                acceptWine(out, ObjectRegistry.STRAD_WINE.get());
+                acceptWine(out, ObjectRegistry.SOLARIS_WINE.get());
+                acceptWine(out, ObjectRegistry.BOLVAR_WINE.get());
+                acceptWine(out, ObjectRegistry.AEGIS_WINE.get());
+                acceptWine(out, ObjectRegistry.CLARK_WINE.get());
+                acceptWine(out, ObjectRegistry.CHENET_WINE.get());
+                acceptWine(out, ObjectRegistry.KELP_CIDER.get());
+                acceptWine(out, ObjectRegistry.APPLE_WINE.get());
+                acceptWine(out, ObjectRegistry.APPLE_CIDER.get());
+                acceptWine(out, ObjectRegistry.JELLIE_WINE.get());
+                acceptWine(out, ObjectRegistry.RED_WINE.get());
+                acceptWine(out, ObjectRegistry.PRAETORIAN_WINE.get());
+                acceptWine(out, ObjectRegistry.JO_SPECIAL_MIXTURE.get());
+                acceptWine(out, ObjectRegistry.CRISTEL_WINE.get());
+                acceptWine(out, ObjectRegistry.CREEPERS_CRUSH.get());
+                acceptWine(out, ObjectRegistry.VILLAGERS_FRIGHT.get());
+                acceptWine(out, ObjectRegistry.GLOWING_WINE.get());
+                acceptWine(out, ObjectRegistry.MEAD.get());
+                acceptWine(out, ObjectRegistry.BOTTLE_MOJANG_NOIR.get());
+                acceptWine(out, ObjectRegistry.EISWEIN.get());
                 out.accept(ObjectRegistry.WINE_BOTTLE.get());
                 out.accept(ObjectRegistry.APPLE_MASH.get());
                 out.accept(ObjectRegistry.GRAPEVINE_STEM.get());
@@ -168,6 +171,13 @@ public class TabRegistry {
                 }
             })
             .build());
+
+    /** Adds a wine to the creative tab only if it is not listed in {@code disabled_wines}. */
+    private static void acceptWine(CreativeModeTab.Output out, ItemLike wine) {
+        if (!VineryConfig.isDisabled(BuiltInRegistries.ITEM.getKey(wine.asItem()))) {
+            out.accept(wine);
+        }
+    }
 
     public static void init() {
         CREATIVE_MODE_TABS.register();

--- a/common/src/main/java/satisfyu/vinery/util/VillagerUtil.java
+++ b/common/src/main/java/satisfyu/vinery/util/VillagerUtil.java
@@ -1,5 +1,6 @@
 package satisfyu.vinery.util;
 
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.npc.VillagerTrades;
@@ -9,6 +10,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.trading.MerchantOffer;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
+import satisfyu.vinery.config.VineryConfig;
 
 public class VillagerUtil {
 
@@ -73,6 +75,10 @@ public class VillagerUtil {
 
         @Override
         public MerchantOffer getOffer(Entity entity, RandomSource random) {
+            if (VineryConfig.isDisabled(BuiltInRegistries.ITEM.getKey(this.sell.getItem()))) {
+                // Don't offer disabled wines; vanilla trade generation skips null offers.
+                return null;
+            }
             return new MerchantOffer(
                     new ItemStack(Items.EMERALD, this.price), new ItemStack(this.sell.getItem(), this.count), this.maxUses, this.experience, this.multiplier
             );

--- a/common/src/main/resources/assets/vinery/lang/en_us.json
+++ b/common/src/main/resources/assets/vinery/lang/en_us.json
@@ -278,6 +278,8 @@
   "vinery.config.entry.fermentationBarrelTime": "Fermentation Barrel Time",
   "vinery.config.entry.grapeGrowthSpeed": "Grape Growth speed (in %)",
   "vinery.config.entry.enableNetherLattices": "Enable Nether Lattices",
+  "vinery.config.entry.disabledWines": "Disabled Wines",
+  "vinery.config.entry.disabledWines.tooltip": "Wine item IDs to completely disable (e.g. vinery:eiswein). Disabled wines can't be crafted or traded, are hidden from the creative menu and JEI/REI, and existing bottles can't be drunk.",
   "vinery.config.subCategory.wineMaker": "Winemaker Set Bonus",
   "vinery.config.title": "Vinery",
   "vinery.tooltip.winemaker_armor": "Winemaker's Desire:",

--- a/common/src/main/resources/vinery-common.mixins.json
+++ b/common/src/main/resources/vinery-common.mixins.json
@@ -16,7 +16,8 @@
     "PlantBlockMixin",
     "ShovelItemMixin",
     "SpreadingSnowyDirtBlockMixin",
-    "WanderingTraderManagerMixin"
+    "WanderingTraderManagerMixin",
+    "RecipeManagerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
> **Heads up on the version:** I based this on the `v1.4.8-1.20.1` tag (commit `9dedbbfe`). I need this feature on 1.20.1 for prominence modpack, and since there isn't an active 1.20.1 branch anymore, I built it on top of the last 1.20.1 release and opened it against the `1.20.1` branch. I'm just putting it out there so it exists for 1.20.1. dD whatever's useful with it, whether that's merging it, adapting it, porting it to 1.21.1, or closing it. I'm happy to rebase onto a different branch if that helps. GitHub will probably show conflicts since the branch has moved on to 1.21.1, which is expected.

## What this does

Adds a `disabled_wines` list to the config that lets you completely disable any wine. Once a wine is disabled you can't craft it (fermentation barrel, apple press, or Create), it won't show up in the creative menu, JEI/REI, or the recipe book, the winemaker villager and wandering trader won't sell it, and any bottles you already have can't be drunk. The `wine_collector` advancement still works, and the item stays registered so existing worlds don't break.

## Why I made it

I wanted to remove a specific wine from a modpack without deleting the item outright, since that would corrupt any world that already had it.

## Using it

Add item IDs to the `disabled_wines` list, either in `config/vinery/config.json5` or through the in-game config screen (Cloth / Mod Menu → Disabled Wines):

```json
"disabled_wines": ["vinery:eiswein", "vinery:mead"]
```

## How it works

It's basically one main hook plus a few small guards, all reading the same list:

- **Recipes (`RecipeManagerMixin`):** at the tail of `RecipeManager#apply` I drop any recipe whose result is a disabled wine, no matter the recipe type. That single hook handles the fermentation barrel, the apple press, and Create. Create's `ProcessingRecipe#getResultItem` returns its first output, and every Vinery wine recipe only has one output. JEI, REI, and the recipe book all read from the synced `RecipeManager`, so they hide it automatically.
- **Creative tab (`TabRegistry`):** wines go through an `acceptWine` helper that skips disabled ones.
- **Drinking (`DrinkBlockItem#use`):** returns `fail` for a disabled wine, so leftover bottles do nothing.
- **Trades:** `VillagerUtil.SellItemFactory#getOffer` returns `null` for disabled wines, which covers the winemaker villager on both loaders, and `WanderingWinemakerEntity#updateTrades` filters its offers.
- **Advancement (`VineryServerDataProvider`):** `wine_collector` needs you to hold every wine at once, so I rebuild it without the disabled wines (using the Moonlight dynamic data pack that's already there) so it stays completable. `get_wine` is an OR list, so it's already fine.

## Testing

I built and ran it on both Fabric and Forge (1.20.1) with `vinery:eiswein` disabled:

- Forge with Create: the log showed `Removed 2 recipe(s)` (the fermentation one and the Create mixing one), and eiswein was gone from JEI and creative and couldn't be crafted or drunk.
- Fabric: `Removed 1 recipe(s)`, same behaviour.
- Adding and removing wines through the in-game config works and takes effect on world reload.